### PR TITLE
Increase hatch-test job timeout to 40 minutes

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,7 @@ jobs:
   hatch-test:
     name: Test on Python ${{ matrix.python-version }}
     runs-on: ["self-hosted", "buildchain"]
-    timeout-minutes: 20
+    timeout-minutes: 40
     strategy:
       matrix:
         python-version: ["3.12"]


### PR DESCRIPTION
The hatch test suite now runs longer than the default 20 minute runner timeout, causing the docker workflow to fail since it depends on hatch-test via hatch-build.